### PR TITLE
Fix regex to disallow incomplete period specs

### DIFF
--- a/duration.go
+++ b/duration.go
@@ -20,8 +20,8 @@ var (
 
 	tmpl = template.Must(template.New("duration").Parse(`P{{if .Years}}{{.Years}}Y{{end}}{{if .Weeks}}{{.Weeks}}W{{end}}{{if .Days}}{{.Days}}D{{end}}{{if .HasTimePart}}T{{end }}{{if .Hours}}{{.Hours}}H{{end}}{{if .Minutes}}{{.Minutes}}M{{end}}{{if .Seconds}}{{.Seconds}}S{{end}}`))
 
-	full = regexp.MustCompile(`P((?P<year>\d+)Y)?((?P<month>\d+)M)?((?P<day>\d+)D)?(T((?P<hour>\d+)H)?((?P<minute>\d+)M)?((?P<second>\d+)S)?)?`)
-	week = regexp.MustCompile(`P((?P<week>\d+)W)`)
+	full = regexp.MustCompile(`^P((?P<year>\d+)Y)?((?P<month>\d+)M)?((?P<day>\d+)D)?(T((?P<hour>\d+)H)?((?P<minute>\d+)M)?((?P<second>\d+)S)?)?$`)
+	week = regexp.MustCompile(`^P((?P<week>\d+)W)$`)
 )
 
 type Duration struct {
@@ -61,6 +61,13 @@ func FromString(dur string) (*Duration, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		// Check that no component is explicitly 0,
+		// e.g. PT60M0S
+		if val == 0 {
+			return nil, fmt.Errorf("%s cannot be 0", name)
+		}
+
 		switch name {
 		case "year":
 			d.Years = val

--- a/duration_test.go
+++ b/duration_test.go
@@ -1,11 +1,12 @@
 package duration_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
-	duration "github.com/channelmeter/iso8601duration"
-	"github.com/stretchr/testify/assert"
+	"github.com/skyportsystems/iso8601duration"
+	"github.com/skyportsystems/testify/assert"
 )
 
 func TestFromString(t *testing.T) {
@@ -13,11 +14,26 @@ func TestFromString(t *testing.T) {
 
 	// test with bad format
 	_, err := duration.FromString("asdf")
-	assert.Equal(t, err, duration.ErrBadFormat)
+	assert.Equal(t, err, duration.ErrBadFormat, "Bad format")
+
+	_, err = duration.FromString("P1x")
+	assert.Equal(t, err, duration.ErrBadFormat, "Partially bad format")
+
+	_, err = duration.FromString("P1")
+	assert.Equal(t, err, duration.ErrBadFormat, "Incomplete format")
+
+	_, err = duration.FromString("P0Y")
+	assert.Equal(t, err, fmt.Errorf("year cannot be 0"), "No zeros")
+
+	_, err = duration.FromString("P1YT0H")
+	assert.Equal(t, err, fmt.Errorf("hour cannot be 0"), "No partial zeros")
+
+	_, err = duration.FromString("P1YT23Hhello")
+	assert.Equal(t, err, duration.ErrBadFormat, "Substring")
 
 	// test with month
 	_, err = duration.FromString("P1M")
-	assert.Equal(t, err, duration.ErrNoMonth)
+	assert.Equal(t, err, duration.ErrNoMonth, "No months")
 
 	// test with good full string
 	dur, err := duration.FromString("P1Y2DT3H4M5S")


### PR DESCRIPTION
The ISO8601 period formatting was slightly broken, in that incomplete periods like P1x would be parsed as valid.  This pull request provides a fix and adds more unit tests.